### PR TITLE
타이틀 로고 위치 문제

### DIFF
--- a/CSS/nanajam777.css
+++ b/CSS/nanajam777.css
@@ -94,10 +94,10 @@ header .row>div:nth-child(1)>a img {
 }
 
 /* 타이틀 이미지  */
-.fa-user:before {
+.col-xs-4:nth-child(1):before {
     content: var(--img-logo);
-    left: 236px;
-    top: -134px;
+    left: 428px;
+    top: 10px;
     position: absolute;
 }
 

--- a/CSS/nanajam777.css
+++ b/CSS/nanajam777.css
@@ -101,6 +101,10 @@ header .row>div:nth-child(1)>a img {
     position: absolute;
 }
 
+.fa-user:before {
+    display: none;
+}
+
 /* 검색창  */
 header #right-search-form>#right-search-btn {
     color: #70b7ff;


### PR DESCRIPTION
PC에서 메인 타이틀 로고 위치가 알림창에 따라 움직임 https://tgd.kr/20441101

- 타이틀 로고가 뷰어 수 아이콘(사람모양)을 고쳐서 만들어진 앤데, 알림창보다 밑에 있는 애라서 알림창이 생길때 같이 밀림
1) 타이틀 로고를 알림창보다 위에 있는 element의 :before로 만듦
2) 원래 있던 뷰어 수 아이콘(사람모양)은 숨김 (타이틀 로고때문에 없어졌던 앤데 1) 수정으로 다시 생기겨서.. 다시 숨겨버렷어요)