### PR TITLE
debug: "LIVE" text is too big

### DIFF
--- a/CSS/nanajam777.css
+++ b/CSS/nanajam777.css
@@ -293,6 +293,9 @@ header #header-bar #header-top-notice strong.notice-badge {
 #board-info h1>a {
     font-weight: 600;
     font-family: 'BRRA_R';
+}
+
+#board-info h1>a:nth-child(1) {
     font-size: 34px;
 }
 


### PR DESCRIPTION
"우정잉" 글씨가 커지면서 그 옆의 "LIVE"까지 엄청 커져버리는 문제
-> 첫번째 a태그의 글씨만 크게 하도록 수정